### PR TITLE
improvement: remove uneccessary memoization

### DIFF
--- a/src/components/BarGraph/Bar/Bar.tsx
+++ b/src/components/BarGraph/Bar/Bar.tsx
@@ -5,31 +5,29 @@ import styles from './Bar.module.scss';
 
 interface BarProps {
   percent: number;
-  orderType: OrderType,
-  isDesktop: boolean
+  orderType: OrderType;
+  isDesktop: boolean;
 }
 
-const Bar:React.FC<BarProps> = React.memo(({percent, orderType, isDesktop}) => {
+const Bar: React.FC<BarProps> = ({ percent, orderType, isDesktop }) => {
   let barColor = styles['bar-bid'];
   let style = {
     width: `${percent}%`,
-    height: '100%'
+    height: '100%',
   };
 
-  if(orderType === OrderType.ASK) {
+  if (orderType === OrderType.ASK) {
     barColor = styles['bar-ask'];
   }
 
-  if(isDesktop) {
+  if (isDesktop) {
     style = {
       width: '100%',
-      height: `${percent}%`
+      height: `${percent}%`,
     };
   }
 
-  return (
-    <div className={barColor} key={percent} style={style} />
-  )
-});
+  return <div className={barColor} key={percent} style={style} />;
+};
 
-export default Bar;
+export default React.memo(Bar);

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -4,38 +4,43 @@ import { Market } from '../../types';
 import styles from './Footer.module.scss';
 
 interface FooterProps {
-  onToggle: (selectedMarket:Market)=>void,
-  isSocketConnected: boolean,
-  selectedMarket: Market
+  onToggle: (selectedMarket: Market) => void;
+  isSocketConnected: boolean;
+  selectedMarket: Market;
 }
 
 let isLoaded = false;
-const Footer:React.FC<FooterProps>  = ({onToggle, isSocketConnected, selectedMarket}) => {
+const Footer: React.FC<FooterProps> = ({
+  onToggle,
+  isSocketConnected,
+  selectedMarket,
+}) => {
   useEffect(() => {
     isLoaded = true;
-  }, [])
+  }, []);
 
-  const toggleHandler = (selectedMarket:Market) => {
+  const toggleHandler = (selectedMarket: Market) => {
     let newMarket;
-      if(selectedMarket === Market.XBT_USD) {
-        newMarket = Market.ETH_USD;
-      } else {
-        newMarket = Market.XBT_USD;
-      }
-      
+    if (selectedMarket === Market.XBT_USD) {
+      newMarket = Market.ETH_USD;
+    } else {
+      newMarket = Market.XBT_USD;
+    }
+
     onToggle(newMarket);
-  }
+  };
 
   return (
     <div className={styles['footer']}>
-      <button 
-        disabled={(!isLoaded || !isSocketConnected)} 
-        className={styles['button-toggle']} 
-        onClick={()=> toggleHandler(selectedMarket)}>
+      <button
+        disabled={!isLoaded || !isSocketConnected}
+        className={styles['button-toggle']}
+        onClick={() => toggleHandler(selectedMarket)}
+      >
         Toggle Feed
       </button>
     </div>
-  )
-}
+  );
+};
 
-export default React.memo(Footer);
+export default Footer;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,22 +1,19 @@
 import React from 'react';
 
 import styles from './Header.module.scss';
-import Spread from "../Spread";
+import Spread from '../Spread';
 
 interface HeaderProps {
-  isDesktop: boolean
+  isDesktop: boolean;
 }
 
-const Header:React.FunctionComponent<HeaderProps> = ({isDesktop}) => {
+const Header: React.FunctionComponent<HeaderProps> = ({ isDesktop }) => {
   return (
-  <div className={styles['header']}>
-    <h3 className={styles['title']}>
-      Order Book
-    </h3>
-    { isDesktop && <Spread /> }
-  </div>
-  )
+    <div className={styles['header']}>
+      <h3 className={styles['title']}>Order Book</h3>
+      {isDesktop && <Spread />}
+    </div>
+  );
+};
 
-}
-
-export default React.memo(Header);
+export default Header;

--- a/src/components/Orders/OrderTable/OrderRow/OrderRow.tsx
+++ b/src/components/Orders/OrderTable/OrderRow/OrderRow.tsx
@@ -1,40 +1,50 @@
-import React from "react";
+import React from 'react';
 
-import { OrderType } from "../../../../types";
+import { OrderType } from '../../../../types';
 import styles from './OrderRow.module.scss';
 
 interface OrderRowProps {
-  total: number,
-  size: number,
-  price: number,
-  orderType: OrderType,
-  isDesktop: boolean
+  total: number;
+  size: number;
+  price: number;
+  orderType: OrderType;
+  isDesktop: boolean;
 }
 
-const OrderRow:React.FunctionComponent<OrderRowProps> = ({total, size,price, orderType, isDesktop}) => {
-  const priceColor = orderType === OrderType.BID ? styles['price--bid'] : styles['price--ask'];
-  
-  const totalCell =  
+const OrderRow: React.FunctionComponent<OrderRowProps> = ({
+  total,
+  size,
+  price,
+  orderType,
+  isDesktop,
+}) => {
+  const priceColor =
+    orderType === OrderType.BID ? styles['price--bid'] : styles['price--ask'];
+
+  const totalCell = (
     <td key={`total:${total}`} className={styles['cell']}>
       {total.toLocaleString()}
     </td>
+  );
 
-  const sizeCell =  
+  const sizeCell = (
     <td key={`size:${size}`} className={styles['cell']}>
       {size.toLocaleString()}
     </td>
-    
-  const priceCell =  
+  );
+
+  const priceCell = (
     <td key={`price:${price}`} className={`${styles['cell']} ${priceColor}`}>
-      {price.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
+      {price.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
     </td>
+  );
 
   const columns = [totalCell, sizeCell, priceCell];
 
-  return( 
+  return (
     <tr key={price} className={styles['order']}>
       {orderType === OrderType.BID && isDesktop ? columns : columns.reverse()}
     </tr>
   );
-}
+};
 export default React.memo(OrderRow);

--- a/src/components/Orders/OrderTable/OrderTable.tsx
+++ b/src/components/Orders/OrderTable/OrderTable.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 
 import { DESKTOP_MEDIA } from '../../../constants';
@@ -10,48 +9,66 @@ import OrderRow from './OrderRow';
 import styles from './OrderTable.module.scss';
 
 interface OrderTableProps {
-  feed: Bid | Ask,
-  orderType: OrderType
+  feed: Bid | Ask;
+  orderType: OrderType;
 }
 
-const OrderTable:React.FC<OrderTableProps> = ({feed, orderType}) => {
+const OrderTable: React.FC<OrderTableProps> = ({ feed, orderType }) => {
   let isDesktop = useMediaQuery(DESKTOP_MEDIA);
-  
-  const getRows = (totalAsksArray:number[], list:number[], map:OrderMap, type:OrderType) => {
-    return list.map((price:number, i:number) => {
-        let size = map[price]!;
-        return <OrderRow 
-          key={`${type}:${price}`} 
-          total={totalAsksArray[i]} 
-          size={size} 
-          price={price} 
-          orderType={type}
-          isDesktop={isDesktop}/>
-      });
-  }
 
-  const feedRows = getRows(feed.depthArray, feed.list, feed.map, orderType)
+  const getRows = (
+    totalAsksArray: number[],
+    list: number[],
+    map: OrderMap,
+    type: OrderType
+  ) => {
+    return list.map((price: number, i: number) => {
+      let size = map[price]!;
+      return (
+        <OrderRow
+          key={`${type}:${price}`}
+          total={totalAsksArray[i]}
+          size={size}
+          price={price}
+          orderType={type}
+          isDesktop={isDesktop}
+        />
+      );
+    });
+  };
+
+  const feedRows = getRows(feed.depthArray, feed.list, feed.map, orderType);
 
   return (
-      <div className={styles['order-table']}>
-        {feed.list.length > 0 && <BarGraph 
+    <div className={styles['order-table']}>
+      {feed.list.length > 0 && (
+        <BarGraph
           isDesktop={isDesktop}
           orderType={orderType}
-          depthArray={feed.depthArray}/>
-        }
-        <table>
-          {!(!isDesktop && orderType === OrderType.BID) && <OrderHeader orderType={orderType} /> }
-          <tbody>
-            {(feed.list.length > 0 && !isDesktop && orderType === OrderType.ASK) ? feedRows.reverse() : feedRows}
-          </tbody>
+          depthArray={feed.depthArray}
+        />
+      )}
+      <table>
+        {!(!isDesktop && orderType === OrderType.BID) && (
+          <OrderHeader orderType={orderType} />
+        )}
+        <tbody>
+          {feed.list.length > 0 && !isDesktop && orderType === OrderType.ASK
+            ? feedRows.reverse()
+            : feedRows}
+        </tbody>
       </table>
     </div>
   );
-}
+};
 
-const areEqual = (prevProps:OrderTableProps,nextProps:OrderTableProps) => {
-  return JSON.stringify(prevProps.feed.depthArray) === JSON.stringify(nextProps.feed.depthArray) &&
-  JSON.stringify(prevProps.feed.map) === JSON.stringify(nextProps.feed.map);
-}
+//Makes HUGE rendering performance boost
+const areEqual = (prevProps: OrderTableProps, nextProps: OrderTableProps) => {
+  return (
+    JSON.stringify(prevProps.feed.depthArray) ===
+      JSON.stringify(nextProps.feed.depthArray) &&
+    JSON.stringify(prevProps.feed.map) === JSON.stringify(nextProps.feed.map)
+  );
+};
 
 export default React.memo(OrderTable, areEqual);

--- a/src/components/Orders/Orders.tsx
+++ b/src/components/Orders/Orders.tsx
@@ -1,25 +1,25 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React from 'react';
+import { useSelector } from 'react-redux';
 
-import { ReducersState, OrderType } from "../../types";
+import { ReducersState, OrderType } from '../../types';
 import styles from './Orders.module.scss';
-import Spread from "../Spread";
-import OrderTable from "./OrderTable";
+import Spread from '../Spread';
+import OrderTable from './OrderTable';
 
 interface OrdersProps {
-  isDesktop: boolean
+  isDesktop: boolean;
 }
 
-const Orders:React.FC<OrdersProps>  = ({isDesktop}) => {
-  const { bid, ask } = useSelector((state:ReducersState) => state.feed);
+const Orders: React.FC<OrdersProps> = ({ isDesktop }) => {
+  const { bid, ask } = useSelector((state: ReducersState) => state.feed);
 
-  return(
+  return (
     <div className={styles['orders']}>
-      <OrderTable feed={bid} orderType={OrderType.BID}/>
-      {!isDesktop &&  <Spread/> }
-      <OrderTable feed={ask} orderType={OrderType.ASK}/>
+      <OrderTable feed={bid} orderType={OrderType.BID} />
+      {!isDesktop && <Spread />}
+      <OrderTable feed={ask} orderType={OrderType.ASK} />
     </div>
   );
-}
+};
 
-export default React.memo(Orders)
+export default React.memo(Orders);

--- a/src/components/Spread/Spread.tsx
+++ b/src/components/Spread/Spread.tsx
@@ -1,26 +1,33 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React from 'react';
+import { useSelector } from 'react-redux';
 
-import { ReducersState } from "../../types";
+import { ReducersState } from '../../types';
 import styles from './Spread.module.scss';
 
 const Spread = () => {
-  const highestBidPrice = useSelector((state:ReducersState) => state.feed.bid.highestBidPrice);
-  const lowestAskPrice = useSelector((state:ReducersState) => state.feed.ask.lowestAskPrice);
-  
-  let spread = 0;
-  let percentage = "";
+  const highestBidPrice = useSelector(
+    (state: ReducersState) => state.feed.bid.highestBidPrice
+  );
+  const lowestAskPrice = useSelector(
+    (state: ReducersState) => state.feed.ask.lowestAskPrice
+  );
 
-  if(highestBidPrice !== Number.MIN_SAFE_INTEGER && lowestAskPrice !== Number.MAX_SAFE_INTEGER) {
-    spread = (lowestAskPrice - highestBidPrice);
-    percentage = ((spread/lowestAskPrice) * 100).toFixed(2);
+  let spread = 0;
+  let percentage = '';
+
+  if (
+    highestBidPrice !== Number.MIN_SAFE_INTEGER &&
+    lowestAskPrice !== Number.MAX_SAFE_INTEGER
+  ) {
+    spread = lowestAskPrice - highestBidPrice;
+    percentage = ((spread / lowestAskPrice) * 100).toFixed(2);
   }
-  
+
   return (
     <h4 className={styles['spread']}>
       Spread: {spread && `${spread.toFixed(1)} (${percentage}%)`}
     </h4>
   );
-}
+};
 
-export default React.memo(Spread);
+export default Spread;


### PR DESCRIPTION
There are some memoized components that do not improve render performance when analyzed with the **React Profiler** dev tool. Memoization should only be used when there is an impact on performance proven by user experience or a profiler.

memoization removed from:
`Header`
`Footer`
`Spread`

memoization added on:
`Bar`

Proof:

`Header`, `Footer`, and `Spread` are rendered in the first 2 frames:
![Screen Shot 2022-11-03 at 11 18 41 AM](https://user-images.githubusercontent.com/24517687/199745424-199b11da-3a04-4fae-8a5c-56945abf58c2.png)
![Screen Shot 2022-11-03 at 11 05 21 AM](https://user-images.githubusercontent.com/24517687/199744891-7472e4bf-f70e-4cfa-b64b-fbb2dbaa3679.png)


Subsequent impact on performance is caused by the `Orders` component and it children
![Screen Shot 2022-11-03 at 11 05 37 AM](https://user-images.githubusercontent.com/24517687/199745627-589751b9-cf64-4f7e-80d2-9f04c83953a6.png)

![Screen Shot 2022-11-03 at 11 05 50 AM](https://user-images.githubusercontent.com/24517687/199745661-76801f02-1340-4651-a2d6-a3290300c384.png)


![Screen Shot 2022-11-03 at 11 23 10 AM](https://user-images.githubusercontent.com/24517687/199746448-8f75965a-6728-4a11-a49d-1798e95b4de6.png)


Finally, an example of render performance without memoization:
![Screen Shot 2022-11-03 at 11 33 59 AM](https://user-images.githubusercontent.com/24517687/199749693-7d4abb03-86c1-41b1-a89e-bbb5ce7dc406.png)


