### PR TITLE
fix: css - replace hyphen with camelcase naming convention and remove unnecessary nesting

### DIFF
--- a/src/components/BarGraph/Bar/Bar.module.scss
+++ b/src/components/BarGraph/Bar/Bar.module.scss
@@ -1,14 +1,6 @@
 @import '../../../_media.scss';
 
 .bar {
-  &-bid {
-    background: #143c3c;
-  }
-
-  &-ask {
-    background: #45212d;
-  }
-
   width: var(--percent);
   height: 100%;
 
@@ -16,4 +8,12 @@
     width: 100%;
     height: var(--percent);
   }
+}
+
+.bid {
+  background: #143c3c;
+}
+
+.ask {
+  background: #45212d;
 }

--- a/src/components/BarGraph/Bar/Bar.tsx
+++ b/src/components/BarGraph/Bar/Bar.tsx
@@ -10,16 +10,17 @@ interface BarProps {
 }
 
 const Bar = ({ percent, orderType }: BarProps) => {
-  let barColor = styles['bar-bid'];
-
-  if (orderType === OrderType.ASK) {
-    barColor = styles['bar-ask'];
-  }
-
   const style = { '--percent': `${percent}%` } as CSSProperties;
 
   return (
-    <rect className={cn(styles.bar, barColor)} key={percent} style={style} />
+    <rect
+      className={cn(
+        styles.bar,
+        orderType === OrderType.BID ? styles.bid : styles.ask
+      )}
+      key={percent}
+      style={style}
+    />
   );
 };
 

--- a/src/components/BarGraph/BarGraph.tsx
+++ b/src/components/BarGraph/BarGraph.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cn from 'classnames';
 
 import styles from './BarGraph.module.scss';
@@ -19,10 +18,10 @@ const BarGraph = ({ depthArray, orderType }: BarGraphProps) => {
 
   return (
     <div
-      className={cn(styles.graph, {
-        [styles.ask]: orderType === OrderType.ASK,
-        [styles.bid]: orderType === OrderType.BID,
-      })}
+      className={cn(
+        styles.graph,
+        orderType === OrderType.ASK ? styles.ask : styles.bid
+      )}
     >
       {list}
     </div>

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -6,29 +6,29 @@
   background-color: $orderbook-background;
   padding: 0.9375rem;
   border-top: 1px solid #262e3e;
+}
 
-  .button-toggle {
-    border: none;
-    width: 6.25rem;
-    height: 1.875rem;
-    border-radius: 0.375rem;
-    background-color: #614ee2;
-    color: white;
-    font-weight: bold;
-    font-size: 0.8rem;
-    cursor: pointer;
+.buttonToggle {
+  border: none;
+  width: 6.25rem;
+  height: 1.875rem;
+  border-radius: 0.375rem;
+  background-color: #614ee2;
+  color: white;
+  font-weight: bold;
+  font-size: 0.8rem;
+  cursor: pointer;
 
-    &:hover {
-      background-color: #211b53;
-    }
+  &:hover {
+    background-color: #211b53;
+  }
 
-    &:active {
-      background-color: #6c63c4;
-    }
+  &:active {
+    background-color: #6c63c4;
+  }
 
-    &:disabled {
-      background-color: #38373b;
-      color: darkgray;
-    }
+  &:disabled {
+    background-color: #38373b;
+    color: darkgray;
   }
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { Market } from '../../types';
 import styles from './Footer.module.scss';
@@ -31,10 +31,10 @@ const Footer = ({
   };
 
   return (
-    <footer className={styles['footer']}>
+    <footer className={styles.footer}>
       <button
         disabled={!isLoaded || !isSocketConnected}
-        className={styles['button-toggle']}
+        className={styles.buttonToggle}
         onClick={() => toggleHandler(selectedMarket)}
       >
         Toggle Feed

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -13,17 +13,17 @@
     position: relative;
     justify-content: center;
   }
+}
 
-  .title {
-    width: 33.3%;
-    padding: 0 0 0 0.9375rem;
-    margin: 0;
-    font-size: 1.17em;
+.title {
+  width: 33.3%;
+  padding: 0 0 0 0.9375rem;
+  margin: 0;
+  font-size: 1.17em;
 
-    @include not-mobile {
-      position: absolute;
-      left: 0;
-    }
+  @include not-mobile {
+    position: absolute;
+    left: 0;
   }
 }
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
-
 import styles from './Header.module.scss';
 import Spread from '../Spread';
 
 const Header = () => {
   return (
-    <header className={styles['header']}>
-      <h1 className={styles['title']}>Order Book</h1>
+    <header className={styles.header}>
+      <h1 className={styles.title}>Order Book</h1>
       <div className={styles.spread}>
         <Spread />
       </div>

--- a/src/components/Notification/Notification.module.scss
+++ b/src/components/Notification/Notification.module.scss
@@ -1,4 +1,4 @@
-.button-reconnect {
+.buttonReconnect {
   padding: 0.625rem;
   border: none;
   background-color: rgb(141, 7, 7);

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styles from './Notification.module.scss';
 
 interface NotificationProps {
@@ -8,7 +6,7 @@ interface NotificationProps {
 
 const Notification = ({ onReconnectSocket }: NotificationProps) => {
   return (
-    <button onClick={onReconnectSocket} className={styles['button-reconnect']}>
+    <button onClick={onReconnectSocket} className={styles.buttonReconnect}>
       Orderbook Disconnected: RECONNECT
     </button>
   );

--- a/src/components/Orders/OrderTable/OrderHeader/OrderHeader.module.scss
+++ b/src/components/Orders/OrderTable/OrderHeader/OrderHeader.module.scss
@@ -6,20 +6,20 @@
   display: flex;
   justify-content: flex-end;
   width: 100%;
+}
 
-  .row {
-    display: flex;
-    width: 100%;
-    padding: 0.25rem;
-    padding-right: 2rem;
+.row {
+  display: flex;
+  width: 100%;
+  padding: 0.25rem;
+  padding-right: 2rem;
+}
 
-    .cell {
-      color: $header-color;
-      display: flex;
-      justify-content: flex-end;
-      width: 33.3%;
-    }
-  }
+.cell {
+  color: $header-color;
+  display: flex;
+  justify-content: flex-end;
+  width: 33.3%;
 }
 
 .hideOnMobile {

--- a/src/components/Orders/OrderTable/OrderHeader/OrderHeader.tsx
+++ b/src/components/Orders/OrderTable/OrderHeader/OrderHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cn from 'classnames';
 
 import { OrderType } from '../../../../types';
@@ -16,18 +15,18 @@ const OrderHeader = ({ orderType }: OrderHeaderProp) => {
   }
 
   const headerElements = headerNames.map((name) => (
-    <th key={name} scope="col" className={styles['cell']}>
+    <th key={name} scope="col" className={styles.cell}>
       {name}
     </th>
   ));
 
   return (
     <thead
-      className={cn(styles['header'], {
+      className={cn(styles.header, {
         [styles.hideOnMobile]: orderType === OrderType.BID,
       })}
     >
-      <tr className={styles['row']}>{headerElements}</tr>
+      <tr className={styles.row}>{headerElements}</tr>
     </thead>
   );
 };

--- a/src/components/Orders/OrderTable/OrderRow/OrderRow.module.scss
+++ b/src/components/Orders/OrderTable/OrderRow/OrderRow.module.scss
@@ -5,20 +5,20 @@
   justify-content: flex-end;
   padding: 5px;
   padding-right: 2rem;
+}
 
-  .cell {
-    width: 33.3%;
-    display: flex;
-    justify-content: flex-end;
+.cell {
+  width: 33.3%;
+  display: flex;
+  justify-content: flex-end;
+}
 
-    &.price--bid {
-      color: #2fc08d;
-    }
+.priceBid {
+  color: #2fc08d;
+}
 
-    &.price--ask {
-      color: #e64d55;
-    }
-  }
+.priceAsk {
+  color: #e64d55;
 }
 
 .bidColumn {

--- a/src/components/Orders/OrderTable/OrderRow/OrderRow.tsx
+++ b/src/components/Orders/OrderTable/OrderRow/OrderRow.tsx
@@ -17,23 +17,26 @@ const OrderRow: React.FunctionComponent<OrderRowProps> = ({
   price,
   orderType,
 }) => {
-  const priceColor =
-    orderType === OrderType.BID ? styles['price--bid'] : styles['price--ask'];
-
   const totalCell = (
-    <td key={`total:${total}`} className={styles['cell']}>
+    <td key={`total:${total}`} className={styles.cell}>
       {total.toLocaleString()}
     </td>
   );
 
   const sizeCell = (
-    <td key={`size:${size}`} className={styles['cell']}>
+    <td key={`size:${size}`} className={styles.cell}>
       {size.toLocaleString()}
     </td>
   );
 
   const priceCell = (
-    <td key={`price:${price}`} className={`${styles['cell']} ${priceColor}`}>
+    <td
+      key={`price:${price}`}
+      className={cn(
+        styles.cell,
+        orderType === OrderType.BID ? styles.priceBid : styles.priceAsk
+      )}
+    >
       {price.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
     </td>
   );
@@ -43,10 +46,10 @@ const OrderRow: React.FunctionComponent<OrderRowProps> = ({
   return (
     <tr
       key={price}
-      className={cn(styles['order'], {
-        [styles.bidColumn]: orderType === OrderType.BID,
-        [styles.askColumn]: orderType === OrderType.ASK,
-      })}
+      className={cn(
+        styles.order,
+        orderType === OrderType.BID ? styles.bidColumn : styles.askColumn
+      )}
     >
       {columns}
     </tr>

--- a/src/components/Orders/OrderTable/OrderTable.tsx
+++ b/src/components/Orders/OrderTable/OrderTable.tsx
@@ -43,10 +43,11 @@ const OrderTable = ({ feed, orderType }: OrderTableProps) => {
       <table className={styles.orderTable}>
         <OrderHeader orderType={orderType} />
         <tbody
-          className={cn(styles.orderTableBody, {
-            [styles.ask]: feed.list.length > 0 && orderType === OrderType.ASK,
-            [styles.bid]: feed.list.length > 0 && orderType === OrderType.BID,
-          })}
+          className={cn(
+            styles.orderTableBody,
+            feed.list.length > 0 &&
+              (orderType === OrderType.ASK ? styles.ask : styles.bid)
+          )}
         >
           {feedRows}
         </tbody>

--- a/src/components/Orders/Orders.tsx
+++ b/src/components/Orders/Orders.tsx
@@ -10,7 +10,7 @@ const Orders = () => {
   const { bid, ask } = useSelector((state: ReducersState) => state.feed);
 
   return (
-    <main className={styles['orders']}>
+    <main className={styles.orders}>
       <OrderTable feed={bid} orderType={OrderType.BID} />
       <div className={styles.spread}>
         <Spread />

--- a/src/components/Spread/Spread.tsx
+++ b/src/components/Spread/Spread.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { ReducersState } from '../../types';
@@ -24,7 +23,7 @@ const Spread = () => {
   }
 
   return (
-    <h2 className={styles['spread']}>
+    <h2 className={styles.spread}>
       Spread: {spread && `${spread.toFixed(1)} (${percentage}%)`}
     </h2>
   );

--- a/src/container/Orderbook.tsx
+++ b/src/container/Orderbook.tsx
@@ -51,7 +51,7 @@ const Orderbook = () => {
   }
 
   return (
-    <div className={styles['orderbook']}>
+    <div className={styles.orderbook}>
       {isLoaded && !isSocketConnected && (
         <Notification onReconnectSocket={reconnectSocketHandler} />
       )}


### PR DESCRIPTION
CSS kebab-casing notation is unnecessary because [CSS modules recommends camelCasing instead](https://github.com/css-modules/css-modules#naming).

CSS nesting is also unnecessary because CSS modules provides locally-scoped class names. Nesting for readability only creates a bigger stylesheet.