### PR TITLE
feat: blur effect when loading/switching between contracts

### DIFF
--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -5,14 +5,14 @@ import { Market } from '../../types';
 import Footer from './Footer';
 
 describe('Footer component', () => {
-  const isConnected = true;
+  const isConnected = false;
   const selectedMarket = Market.XBT_USD;
   const toggleHandlerMock = jest.fn();
 
   const { container, getByText } = render(
     <Footer
       onToggle={toggleHandlerMock}
-      isSocketConnected={isConnected}
+      isDisabled={isConnected}
       selectedMarket={selectedMarket}
     />
   );
@@ -32,7 +32,7 @@ describe('Footer component', () => {
     const { container, getByText } = render(
       <Footer
         onToggle={toggleHandlerMock}
-        isSocketConnected={isConnected}
+        isDisabled={isConnected}
         selectedMarket={selectedMarket}
       />
     );
@@ -50,7 +50,7 @@ describe('Footer component', () => {
     const { container, getByText } = render(
       <Footer
         onToggle={toggleHandlerMock}
-        isSocketConnected={!isConnected}
+        isDisabled={!isConnected}
         selectedMarket={selectedMarket}
       />
     );

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -5,16 +5,12 @@ import styles from './Footer.module.scss';
 
 interface FooterProps {
   onToggle: (selectedMarket: Market) => void;
-  isSocketConnected: boolean;
+  isDisabled: boolean;
   selectedMarket: Market;
 }
 
 let isLoaded = false;
-const Footer = ({
-  onToggle,
-  isSocketConnected,
-  selectedMarket,
-}: FooterProps) => {
+const Footer = ({ onToggle, isDisabled, selectedMarket }: FooterProps) => {
   useEffect(() => {
     isLoaded = true;
   }, []);
@@ -33,7 +29,7 @@ const Footer = ({
   return (
     <footer className={styles.footer}>
       <button
-        disabled={!isLoaded || !isSocketConnected}
+        disabled={!isLoaded || isDisabled}
         className={styles.buttonToggle}
         onClick={() => toggleHandler(selectedMarket)}
       >

--- a/src/components/Orders/OrderTable/OrderTable.module.scss
+++ b/src/components/Orders/OrderTable/OrderTable.module.scss
@@ -12,7 +12,7 @@
   display: flex;
   flex-direction: column;
 
-  min-height: 29.713125rem;
+  min-height: 31.8125rem;
 }
 
 .orderTableBody {

--- a/src/components/Orders/OrderTable/OrderTable.tsx
+++ b/src/components/Orders/OrderTable/OrderTable.tsx
@@ -32,7 +32,6 @@ const OrderTable = ({ feed, orderType }: OrderTableProps) => {
       );
     });
   };
-
   const feedRows = getRows(feed.depthArray, feed.list, feed.map, orderType);
 
   return (

--- a/src/container/Orderbook.module.scss
+++ b/src/container/Orderbook.module.scss
@@ -17,3 +17,7 @@
     max-width: 56.25rem;
   }
 }
+
+.blur {
+  filter: blur(3px);
+}

--- a/src/container/Orderbook.tsx
+++ b/src/container/Orderbook.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from 'react';
+import cn from 'classnames';
 
 import styles from './Orderbook.module.scss';
 import { Market, VisibilityState } from '../types';
@@ -18,6 +19,7 @@ const Orderbook = () => {
     selectedMarket,
     changeMarket,
     connectionError,
+    isSubscribed,
   } = useSocket();
 
   const reconnectSocketHandler = useCallback(() => {
@@ -52,7 +54,7 @@ const Orderbook = () => {
   }
 
   return (
-    <div className={styles.orderbook}>
+    <div className={cn(styles.orderbook, { [styles.blur]: !isSubscribed })}>
       {connectionError && (
         <ErrorModal
           message="Connection Failed"
@@ -72,7 +74,7 @@ const Orderbook = () => {
       <Footer
         onToggle={toggleHandler}
         selectedMarket={selectedMarket}
-        isSocketConnected={isSocketConnected!}
+        isDisabled={!isSocketConnected || !isSubscribed}
       />
     </div>
   );

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -77,6 +77,7 @@ const useSocket = () => {
     selectedMarket,
     changeMarket,
     connectionError,
+    isSubscribed,
   };
 };
 


### PR DESCRIPTION
The orderbook has no way to notify the user when data is loading. Therefore the user might think the contract is not responding on initial load or when switching from one contract to another.

The solution was to add a blur effect when the data is loading.