### PR TITLE
fix: disable toggle button until subscribed to new market

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Market } from '../../types';
 import styles from './Footer.module.scss';
@@ -9,27 +9,26 @@ interface FooterProps {
   selectedMarket: Market;
 }
 
-let isLoaded = false;
 const Footer = ({ onToggle, isDisabled, selectedMarket }: FooterProps) => {
+  const [tempDisabled, setTempDisabled] = useState(true);
   useEffect(() => {
-    isLoaded = true;
-  }, []);
+    if (selectedMarket !== Market.NONE) {
+      setTempDisabled(false);
+    }
+  }, [selectedMarket]);
 
   const toggleHandler = (selectedMarket: Market) => {
-    let newMarket;
-    if (selectedMarket === Market.XBT_USD) {
-      newMarket = Market.ETH_USD;
-    } else {
-      newMarket = Market.XBT_USD;
-    }
+    const newMarket =
+      selectedMarket === Market.XBT_USD ? Market.ETH_USD : Market.XBT_USD;
 
+    setTempDisabled(true);
     onToggle(newMarket);
   };
 
   return (
     <footer className={styles.footer}>
       <button
-        disabled={!isLoaded || isDisabled}
+        disabled={isDisabled || tempDisabled}
         className={styles.buttonToggle}
         onClick={() => toggleHandler(selectedMarket)}
       >

--- a/src/container/Orderbook.tsx
+++ b/src/container/Orderbook.tsx
@@ -76,7 +76,7 @@ const Orderbook = () => {
       <Footer
         onToggle={toggleHandler}
         selectedMarket={selectedMarket}
-        isDisabled={!isSocketConnected || !isSubscribed}
+        isDisabled={!isSocketConnected}
       />
     </div>
   );


### PR DESCRIPTION
Toggling the feed button creates a false experience because the user still thinks they can keep toggling it. In order to provide an accurate experience, the button is now disabled after clicking until subscribed to the new market.