### PR TITLE
fix: display only one modal at a time

### DIFF
--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -9,7 +9,7 @@
   top: 0px;
   background-color: black;
   opacity: 0.7;
-  z-index: 2;
+  z-index: 1;
 }
 
 .modal {

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -25,7 +25,7 @@ describe('Modal component', () => {
   test('should render Error Modal', async () => {
     const reconnectHandlerMock = jest.fn();
 
-    const { container, getByText } = render(
+    const { getByText } = render(
       <Modal
         message="Connection Failed"
         buttonText="RETRY"
@@ -35,16 +35,14 @@ describe('Modal component', () => {
     );
 
     const buttonEl = getByText('RETRY');
-    await userEvent.click(buttonEl);
 
-    expect(container).toBeTruthy();
-    expect(reconnectHandlerMock.mock.calls.length).toEqual(1);
+    expect(buttonEl).toBeTruthy();
   });
 
   test('should render Warning Modal', async () => {
     const reconnectHandlerMock = jest.fn();
 
-    const { container, getByText, getByRole } = render(
+    const { container, getByRole } = render(
       <Modal
         message="Orderbook Disconnected"
         buttonText="reconnect"
@@ -54,12 +52,9 @@ describe('Modal component', () => {
     );
 
     const modal = getByRole('alertdialog');
-    const buttonEl = getByText('reconnect');
-    await userEvent.click(buttonEl);
 
     expect(container).toBeTruthy();
     expect(modal).toBeTruthy();
-    expect(reconnectHandlerMock.mock.calls.length).toEqual(1);
   });
 
   test('should click button in modal', async () => {

--- a/src/components/Orders/OrderTable/OrderTable.test.tsx
+++ b/src/components/Orders/OrderTable/OrderTable.test.tsx
@@ -5,8 +5,6 @@ import { OrderType } from '../../../types';
 import { bid as bidMock, ask as askMock } from '../../../mocks';
 
 describe('OrderTable component', () => {
-  console.log(global.screen.width);
-
   test('should render OrderTable ask feed', () => {
     const { container, getAllByRole } = render(
       <OrderTable feed={bidMock} orderType={OrderType.ASK} />

--- a/src/container/Orderbook.tsx
+++ b/src/container/Orderbook.tsx
@@ -10,7 +10,6 @@ import useSocket from '../hooks/useSocket';
 import Modal from '../components/Modal';
 
 const VISIBILITY_CHANGE = 'visibilitychange';
-let isLoaded = false;
 const Orderbook = () => {
   const {
     isSocketConnected,
@@ -49,10 +48,6 @@ const Orderbook = () => {
       window.removeEventListener(VISIBILITY_CHANGE, toggleConnectionHandler);
   }, [toggleConnectionHandler]);
 
-  if (isSocketConnected) {
-    isLoaded = true;
-  }
-
   return (
     <div className={cn(styles.orderbook, { [styles.blur]: !isSubscribed })}>
       {connectionError ? (
@@ -63,7 +58,7 @@ const Orderbook = () => {
           status={ModalStatus.ERROR}
         />
       ) : (
-        isLoaded &&
+        selectedMarket !== Market.NONE &&
         !isSocketConnected && (
           <Modal
             message="Orderbook Disconnected"

--- a/src/store/socket-slice.ts
+++ b/src/store/socket-slice.ts
@@ -14,10 +14,10 @@ const socketSlice = createSlice({
   initialState: initialSocketState,
   reducers: {
     sendMessage(state: SocketState) {
-      state.connectionError = false;
       state.sendingMessage = true;
     },
     connectSuccess(state: SocketState) {
+      state.connectionError = false;
       state.sendingMessage = false;
       state.isConnected = true;
     },


### PR DESCRIPTION
When the socket is disconnected from switching browser tabs and then a connection error occurs, two modals pop up. There should only be one modal displayed at a time and the connection error modal should have priority over the other.

- Improved the logic
- Updated unit tests
