### PR TITLE
chore: specify which files to collect test coverage from

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,16 @@
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!src/**/mocks",
+      "!src/*.{ts,tsx}",
+      "src/**/OrderbookSocket.ts",
+      "!src/**/*.stories.tsx",
+      "!src/**/index.ts"
+    ]
+  },
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
Currently test coverage is including Storybook,  mocks, and other irrelevant files.

Specified which files should be part of test coverage and which files to ignore.